### PR TITLE
Fix for regression with CoreFoundation 5.3

### DIFF
--- a/Sources/NetService/FoundationCompat.swift
+++ b/Sources/NetService/FoundationCompat.swift
@@ -1,5 +1,9 @@
 import CoreFoundation
 
+#if !os(Linux)
+internal let kCFSocketReadCallBack = CFSocketCallBackType.readCallBack.rawValue
+#endif
+
 #if os(Linux) && !compiler(>=5.0)
 import class Foundation.RunLoop
 import struct Foundation.RunLoopMode

--- a/Sources/NetService/FoundationCompat.swift
+++ b/Sources/NetService/FoundationCompat.swift
@@ -1,6 +1,6 @@
 import CoreFoundation
 
-#if !os(Linux)
+#if !os(Linux) || compiler(>=5.3)
 internal let kCFSocketReadCallBack = CFSocketCallBackType.readCallBack.rawValue
 #endif
 

--- a/Sources/NetService/NetService.swift
+++ b/Sources/NetService/NetService.swift
@@ -356,7 +356,7 @@ public class NetService {
 
         var context = CFSocketContext(version: 0, info: info, retain: nil, release: nil, copyDescription: nil)
 
-        socket = CFSocketCreateWithNative(nil, fd, CFOptionFlags(CFSocketCallBackType.readCallBack.rawValue), _processResult, &context)
+        socket = CFSocketCreateWithNative(nil, fd, CFOptionFlags(kCFSocketReadCallBack), _processResult, &context)
 
         // Don't close the underlying socket on invalidate, as it is owned by dns_sd.
         var socketFlags = CFSocketGetSocketFlags(socket)

--- a/Sources/NetService/NetServiceBrowser.swift
+++ b/Sources/NetService/NetServiceBrowser.swift
@@ -178,7 +178,7 @@ public class NetServiceBrowser {
         let info = Unmanaged.passUnretained(self).toOpaque()
 
         var context = CFSocketContext(version: 0, info: info, retain: nil, release: nil, copyDescription: nil)
-        socket = CFSocketCreateWithNative(nil, fd, CFOptionFlags(CFSocketCallBackType.readCallBack.rawValue), _processResult, &context)
+        socket = CFSocketCreateWithNative(nil, fd, CFOptionFlags(kCFSocketReadCallBack), _processResult, &context)
 
         // Don't close the underlying socket on invalidate, as it is owned by dns_sd.
         var socketFlags = CFSocketGetSocketFlags(socket)


### PR DESCRIPTION
In CoreFoundation 5.3 `kCFSocketReadCallBack` is no longer defined.