### PR TITLE
Import Glibc on Linux

### DIFF
--- a/Sources/NetService/NetService.swift
+++ b/Sources/NetService/NetService.swift
@@ -7,8 +7,11 @@ import class Foundation.InputStream
 import class Foundation.OutputStream
 import class Foundation.NSNumber
 import class Foundation.RunLoop
-#if os(Linux) && !compiler(>=5.0)
+#if os(Linux)
+import Glibc
+#if !compiler(>=5.0)
 import struct Foundation.RunLoopMode
+#endif
 #endif
 import struct Foundation.TimeInterval
 


### PR DESCRIPTION
I had trouble compiling my dependent project on a Raspberry Pi 4 without importing Glibc into NetService.swift